### PR TITLE
Melhora verificação para criar uma nova aba

### DIFF
--- a/script.gs
+++ b/script.gs
@@ -43,7 +43,7 @@ function __atualizaAtual() {
 function verifyMostRecentSheet() {
   var periodo = getSheetnameData(sheet);
   var today = new Date();
-  if (today > periodo.dataFinal) {
+  if (today.getMonth() > periodo.dataFinal.getMonth()) {
     createNewSheet(today, periodo)
   }
 }

--- a/script.gs
+++ b/script.gs
@@ -59,7 +59,7 @@ function createNewSheet(today, periodo) {
   var target_range = sheet.getRange('A1:G1');
   source_range.copyTo(target_range);
 
-  ss.setColumnWidth(1,7,100);
+  ss.setColumnWidths(1,7,100);
   ss.setColumnWidth(2,500);
   ss.setColumnWidth(7,150);
 


### PR DESCRIPTION
Atualmente a verificação ```today > periodo.dataFinal``` começa a ser verdadeira no começo do último dia do mês e tenta a todo momento criar uma aba que já existe (pois ainda não trocou o mês). Trocar a verificação pelo getMonth() deve resolver isto.

O outro erro é que para setar o tamanho de várias colunas de uma vez o nome da função é no plural: ```setColumnWidths```

![image](https://user-images.githubusercontent.com/3418974/57015520-8e46c500-6beb-11e9-827b-409890b8ddbe.png)